### PR TITLE
fix(api/forge): build version in downloads

### DIFF
--- a/src/api/minecraft/forge/index.ts
+++ b/src/api/minecraft/forge/index.ts
@@ -85,7 +85,7 @@ class Forge {
 		r.headers.set(
 			'Content-Disposition',
 			`attachment; filename=${JSON.stringify(
-				'forge' + '-' + version + '-' + build + '.jar',
+				'forge' + '-' + version + '-' + build.version + '.jar',
 			)}`,
 		);
 		r.headers.set('Content-Type', 'application/java-archive');


### PR DESCRIPTION
actually use the build version instead of `[Object object]`.